### PR TITLE
Tidy, split classes, fix circular dependencies

### DIFF
--- a/renderer/.idea/vcs.xml
+++ b/renderer/.idea/vcs.xml
@@ -5,5 +5,6 @@
     <mapping directory="$PROJECT_DIR$/ext/glm" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ext/json" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ext/pugixml" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ext/stb" vcs="Git" />
   </component>
 </project>

--- a/renderer/CMakeLists.txt
+++ b/renderer/CMakeLists.txt
@@ -1,5 +1,5 @@
 ﻿cmake_minimum_required(VERSION 3.8)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 
 project("renderer")
 

--- a/renderer/CMakeSettings.json
+++ b/renderer/CMakeSettings.json
@@ -9,7 +9,9 @@
       "installRoot": "${projectDir}\\out\\install\\${name}",
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
-      "ctestCommandArgs": ""
+      "ctestCommandArgs": "",
+      "enableClangTidyCodeAnalysis": true,
+      "enableMicrosoftCodeAnalysis": false
     }
   ]
 }

--- a/renderer/main.cpp
+++ b/renderer/main.cpp
@@ -2,11 +2,12 @@
 
 #include "src/renderer.h"
 
-using namespace std;
+#include <filesystem>
 
 int main(int argc, char *argv[]) {
     Renderer renderer;
     renderer.loadTungstenJSON(argv[1]);
+    std::filesystem::remove("out.png");
     renderer.render();
     system("out.png");
     return 0;

--- a/renderer/src/CMakeLists.txt
+++ b/renderer/src/CMakeLists.txt
@@ -1,15 +1,21 @@
 ﻿add_library(core
-    "camera.h"
-    "framebuffer.h"
-    "framebuffer.cpp"
-    "integrator.h"
-    "integrator.cpp"
-    "primitive.h"
-    "renderer.h"
-    "scene.h"
-    "scene.cpp"
-    "usings.h")
+        "camera.h"
+        "framebuffer.h"
+        "framebuffer.cpp"
+        "integrator.h"
+        "integrator.cpp"
+        "material.h"
+        "pathtracer.h"
+        "pathtracer.cpp"
+        "primitive.h"
+        "ray.h"
+        "renderer.h"
+        "scene.h"
+        "sceneparser.h"
+        "sceneparser.cpp"
+        "shape.h"
+        "usings.h")
 target_link_libraries(core
-    glm
-    nlohmann_json
-    pugixml)
+        glm
+        nlohmann_json
+        pugixml)

--- a/renderer/src/camera.h
+++ b/renderer/src/camera.h
@@ -1,62 +1,66 @@
 #pragma once
 
+#include <cmath>
+
 #include "usings.h"
 
 class Camera {
 public:
-    Camera() {};
-    Camera(int resx,
-        int resy,
-        float fovd,
-        const mat4f& transform) :
-        resx(resx),
-        resy(resy),
-        aspect((float)resy / (float)resx),
-        fovd(fovd),
-        fovr(d_to_r(fovd)),
-        toPlane(0),
-        planeArea(0),
-        invPlaneArea(0),
-        eye(0),
-        center(0),
-        up(0),
-        transform(transform) {};
-    Camera(int resx,
-        int resy,
-        float fovd,
-        const vec3f& eye,
-        const vec3f& center,
-        const vec3f& up) :
-        resx(resx),
-        resy(resy),
-        aspect((float)resy / (float)resx),
-        fovd(fovd),
-        fovr(d_to_r(fovd)),
-        toPlane(1.0f / tan(fovr * 0.5f)),
-        planeArea((2.0f / toPlane)* (2.0f * aspect / toPlane)),
-        invPlaneArea(1.0f / planeArea),
-        eye(eye),
-        center(center),
-        up(up),
-        transform(lookAt(eye, center - eye, up)) {};
+    Camera() = default;
 
-    vec3f sampleDirection(vec2i px) {
+    Camera(int resx,
+           int resy,
+           float fovd,
+           const mat4f &transform) :
+            resx(resx),
+            resy(resy),
+            aspect((float) resy / (float) resx),
+            fovd(fovd),
+            fovr(d_to_r(fovd)),
+            toPlane(0),
+            planeArea(0),
+            invPlaneArea(0),
+            eye(0),
+            center(0),
+            up(0),
+            transform(transform) {};
+
+    Camera(int resx,
+           int resy,
+           float fovd,
+           const vec3f &eye,
+           const vec3f &center,
+           const vec3f &up) :
+            resx(resx),
+            resy(resy),
+            aspect((float) resy / (float) resx),
+            fovd(fovd),
+            fovr(d_to_r(fovd)),
+            toPlane(1.0f / std::tan(fovr * 0.5f)),
+            planeArea((2.0f / toPlane) * (2.0f * aspect / toPlane)),
+            invPlaneArea(1.0f / planeArea),
+            eye(eye),
+            center(center),
+            up(up),
+            transform(lookAt(eye, center - eye, up)) {};
+
+    [[nodiscard]] vec3f sampleDirection(vec2i px) const {
         return normalize(transformVec(transform, vec3f(
-            -1.0f + 2.0f * (float(px.x) / float(resx)),
-            aspect - 2.0f * aspect * (float(px.y) / float(resy)),
-            toPlane)));
+                -1.0f + 2.0f * (float(px.x) / float(resx)),
+                aspect - 2.0f * aspect * (float(px.y) / float(resy)),
+                toPlane)));
     }
 
-    static mat4f lookAt(const vec3f& pos, const vec3f& fwd, const vec3f& up) {
+    static mat4f lookAt(const vec3f &pos, const vec3f &fwd, const vec3f &up) {
         vec3f f = glm::normalize(fwd);
         vec3f r = glm::normalize(glm::cross(f, up));
         vec3f u = glm::normalize(glm::cross(r, f));
-        return mat4f(
-            r.x, r.y, r.z, 0.f,
-            u.x, u.y, u.z, 0.f,
-            f.x, f.y, f.z, 0.f,
-            pos.x, pos.y, pos.z, 1.f
-        );
+        return {
+                r.x, r.y, r.z, 0.f,
+                u.x, u.y, u.z, 0.f,
+                f.x, f.y, f.z, 0.f,
+                pos.x, pos.y, pos.z, 1.f
+        };
     }
 
     int resx;

--- a/renderer/src/framebuffer.cpp
+++ b/renderer/src/framebuffer.cpp
@@ -8,28 +8,28 @@
 vec3c FrameBuffer::Rgb(int px) {
     vec3f pixel = get(px);
     return {
-        static_cast<char>(256 * clamp(pixel.r)),
-        static_cast<char>(256 * clamp(pixel.g)),
-        static_cast<char>(256 * clamp(pixel.b))
+            static_cast<char>(256 * clamp(pixel.r)),
+            static_cast<char>(256 * clamp(pixel.g)),
+            static_cast<char>(256 * clamp(pixel.b))
     };
 }
 
 vec4c FrameBuffer::Rgba(int px) {
     vec3f pixel = get(px);
     return {
-        static_cast<char>(256 * clamp(pixel.r)),
-        static_cast<char>(256 * clamp(pixel.g)),
-        static_cast<char>(256 * clamp(pixel.b)),
-        255
+            static_cast<char>(256 * clamp(pixel.r)),
+            static_cast<char>(256 * clamp(pixel.g)),
+            static_cast<char>(256 * clamp(pixel.b)),
+            255
     };
 }
 
-void FrameBuffer::toPpm(const char* filename) {
+void FrameBuffer::toPpm(const char *filename) {
     std::ofstream out(filename);
     out << "P3\n" << resx << ' ' << resy << "\n255\n";
     for (int j = 0; j < resy; j++) {
         for (int i = 0; i < resx; i++) {
-            vec3f px = Rgb(vec2i(i,j));
+            vec3f px = Rgb(vec2i(i, j));
             out << px.r << ' '
                 << px.g << ' '
                 << px.b << '\n';
@@ -37,7 +37,7 @@ void FrameBuffer::toPpm(const char* filename) {
     }
 }
 
-void FrameBuffer::toPng(const char* filename) {
+void FrameBuffer::toPng(const char *filename) {
     rgbBuf = vector<vec4c>(resx * resy);
     for (int i = 0; i < buf.size(); i++) {
         rgbBuf[i] = Rgba(i);

--- a/renderer/src/framebuffer.h
+++ b/renderer/src/framebuffer.h
@@ -4,26 +4,35 @@
 
 class FrameBuffer {
 public:
-    FrameBuffer() {};
+    FrameBuffer() = default;
+
     FrameBuffer(int resx, int resy) :
-        resx(resx),
-        resy(resy),
-        buf(vector<vec3f>(resx * resy)) {};
+            resx(resx),
+            resy(resy),
+            buf(vector<vec3f>(resx * resy)) {};
 
     void set(int px, vec3f v) { buf[px] = v; }
+
     void set(vec2i px, vec3f v) { set(px.y * resx + px.x, v); }
+
     vec3f get(int px) { return buf[px]; }
+
     vec3f get(vec2i px) { return get(px.y * resx + px.x); }
+
     vec3c Rgb(int px);
+
     vec3c Rgb(vec2i px) { return Rgb(px.y * resx + px.x); }
+
     vec4c Rgba(int px);
+
     vec4c Rgba(vec2i px) { return Rgba(px.y * resx + px.x); }
 
-    void toPpm(const char* filename);
-    void toPng(const char* filename);
+    void toPpm(const char *filename);
 
-    int resx;
-    int resy;
+    void toPng(const char *filename);
+
+    int resx{};
+    int resy{};
     vector<vec3f> buf;
     vector<vec4c> rgbBuf;
 };

--- a/renderer/src/integrator.cpp
+++ b/renderer/src/integrator.cpp
@@ -1,20 +1,14 @@
 #include "integrator.h"
 
-#include "camera.h"
-#include "framebuffer.h"
-#include "scene.h"
-
-void DebugIntegrator::render(Scene& scene, FrameBuffer& frame) {
+void PathIntegrator::render(Scene &scene, FrameBuffer &frame) {
     Camera cam = scene.camera;
     int resx = cam.resx;
     int resy = cam.resy;
+    tracer = make_unique<DebugPathTracer>();
     for (int j = 0; j < resy; j++) {
         for (int i = 0; i < resx; i++) {
             vec2i px(i, j);
-            vec3f colorizedDirection = (cam.sampleDirection(px) + 1.0f) / 2.0f;
-            frame.set(px, colorizedDirection);
+            frame.set(px, tracer->trace(scene, px));
         }
     }
 };
-
-void PathIntegrator::render(Scene& scene, FrameBuffer& frame) {};

--- a/renderer/src/integrator.h
+++ b/renderer/src/integrator.h
@@ -2,21 +2,20 @@
 
 #include "usings.h"
 
-class Scene;
-class FrameBuffer;
+#include "framebuffer.h"
+#include "pathtracer.h"
+#include "scene.h"
 
 class Integrator {
 public:
     virtual ~Integrator() = default;
-    virtual void render(Scene& scene, FrameBuffer& frame) = 0;
-};
 
-class DebugIntegrator : public Integrator {
-public:
-    void render(Scene& scene, FrameBuffer& frame);
+    virtual void render(Scene &scene, FrameBuffer &frame) = 0;
+
+    unique_ptr<Tracer> tracer;
 };
 
 class PathIntegrator : public Integrator {
 public:
-    void render(Scene& scene, FrameBuffer& frame);
+    void render(Scene &scene, FrameBuffer &frame) override;
 };

--- a/renderer/src/material.h
+++ b/renderer/src/material.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "usings.h"
+
+class Material {
+public:
+    virtual ~Material() = default;
+    vec3f albedo{};
+};
+
+class Lambertian : public Material {
+public:
+    explicit Lambertian(const vec3f &albedo) {
+        this->albedo = albedo;
+    };
+};
+
+class Emitter {
+public:
+    explicit Emitter(const vec3f &radiance) : radiance(radiance) {};
+    vec3f radiance;
+};

--- a/renderer/src/pathtracer.cpp
+++ b/renderer/src/pathtracer.cpp
@@ -1,0 +1,7 @@
+#include "pathtracer.h"
+
+vec3f DebugPathTracer::trace(const Scene &scene, vec2i px) {
+    Camera cam = scene.camera;
+    vec3f d = cam.sampleDirection(px);
+    return (d + 1.0f) / 2.0f;
+}

--- a/renderer/src/pathtracer.h
+++ b/renderer/src/pathtracer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "usings.h"
+
+#include "ray.h"
+#include "scene.h"
+
+class Tracer {
+public:
+    virtual ~Tracer() = default;
+
+    virtual vec3f trace(const Scene &scene, vec2i px) = 0;
+};
+
+class DebugPathTracer : public Tracer {
+public:
+    vec3f trace(const Scene &scene, vec2i px) override;
+};

--- a/renderer/src/primitive.h
+++ b/renderer/src/primitive.h
@@ -2,111 +2,17 @@
 
 #include "usings.h"
 
-class Ray {
-public:
-    Ray(const vec3f &o, const vec3f &d) :
-        o(o),
-        d(normalize(d)),
-        t(0) {};
-    vec3f at(float dt) const { return o + d * dt; }
-
-    vec3f o;
-    vec3f d;
-    float t;
-};
-
-class Material {
-public:
-    virtual ~Material() {};
-    vec3f albedo;
-};
-
-class Lambertian : public Material {
-public:
-    explicit Lambertian(const vec3f &albedo) {
-        this->albedo = albedo;
-    };
-};
-
-class Emitter {
-public:
-    explicit Emitter(const vec3f &radiance) : radiance(radiance) {};
-    vec3f radiance;
-};
-
-class Shape {
-public:
-    explicit Shape(const mat4f &to_world) :
-        pos(vec3f()),
-        scale(vec3f()),
-        rot3(vec3f()),
-        rot4(mat4f()),
-        invRot(mat4f()),
-        to_world(to_world),
-        to_obj(inverse(to_world)) {};
-    Shape(const vec3f &pos,
-          const vec3f &scale,
-          const vec3f &rot3) :
-        pos(pos),
-        scale(scale),
-        rot3(rot3) {
-        
-        mat4f T(1), R(1);
-        T = glm::translate(T, pos);
-        T = glm::scale(T, scale);
-        R = glm::rotate(R, rot3.x, vec3f(1, 0, 0));
-        R = glm::rotate(R, rot3.y, vec3f(0, 1, 0));
-        R = glm::rotate(R, rot3.z, vec3f(0, 0, 1));
-        T = T * R;
-
-        rot4 = R;
-        invRot = glm::inverse(rot4);
-        to_world = T;
-        to_obj = glm::inverse(T);
-    };
-
-    vec3f pos;
-    vec3f scale;
-    vec3f rot3;
-    mat4f rot4;
-    mat4f invRot;
-    mat4f to_world;
-    mat4f to_obj;
-};
-
-class Rectangle : public Shape {
-public:
-    explicit Rectangle(const mat4f &transform) : Shape(transform) {};
-    Rectangle(const vec3f &pos,
-              const vec3f &scale,
-              const vec3f &rot3) :
-        Shape(pos, scale, rot3) {};
-
-    vec3f a{-1, -1, 0};
-    vec3f b{1, 1, 0};
-    vec3f normal{0, 0, 1};
-};
-
-class Cube : public Shape {
-public:
-    explicit Cube(const mat4f &transform) : Shape(transform) {};
-    Cube(const vec3f &pos,
-         const vec3f &scale,
-         const vec3f &rot3) :
-        Shape(pos, scale, rot3) {};
-
-    vec3f a{-1, -1, -1};
-    vec3f b{1, 1, 1};
-};
+#include "material.h"
+#include "shape.h"
 
 class Primitive {
 public:
     Primitive(shared_ptr<Shape> shape,
               shared_ptr<Material> material,
               shared_ptr<Emitter> emitter) :
-        shape(std::move(shape)),
-        material(std::move(material)),
-        emitter(std::move(emitter)) {};
+            shape(std::move(shape)),
+            material(std::move(material)),
+            emitter(std::move(emitter)) {};
 
     shared_ptr<Shape> shape;
     shared_ptr<Material> material;

--- a/renderer/src/ray.h
+++ b/renderer/src/ray.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "usings.h"
+
+class Ray {
+public:
+    Ray(const vec3f &o, const vec3f &d) :
+            o(o),
+            d(normalize(d)),
+            t(0) {};
+
+    [[nodiscard]] vec3f at(float dt) const { return o + d * dt; }
+
+    vec3f o;
+    vec3f d;
+    float t;
+};

--- a/renderer/src/renderer.h
+++ b/renderer/src/renderer.h
@@ -3,29 +3,28 @@
 #include "usings.h"
 
 #include "framebuffer.h"
+#include "integrator.h"
 #include "scene.h"
+#include "sceneparser.h"
 
 class Renderer {
 public:
-    Renderer() {};
+    Renderer() = default;
 
-    void loadTungstenJSON(const char* filename) {
-        scene = Scene::FromTungstenJSON(filename);
-        frame = FrameBuffer(scene.camera.resx,
-            scene.camera.resy);
+    void loadTungstenJSON(const char *filename) {
+        SceneParser::FromTungstenJSON(scene, frame, integrator, filename);
     }
 
-    void loadMitsubaXML(const char* filename) {
-        scene = Scene::FromMitsubaXML(filename);
-        frame = FrameBuffer(scene.camera.resx,
-            scene.camera.resy);
+    void loadMitsubaXML(const char *filename) {
+        SceneParser::FromMitsubaXML(scene, frame, integrator, filename);
     }
 
     void render() {
-        scene.integrator->render(scene, frame);
+        integrator->render(scene, frame);
         frame.toPng("out.png");
     }
 
     Scene scene;
     FrameBuffer frame;
+    unique_ptr<Integrator> integrator;
 };

--- a/renderer/src/scene.h
+++ b/renderer/src/scene.h
@@ -3,30 +3,23 @@
 #include "usings.h"
 
 #include "camera.h"
-#include "integrator.h"
+#include "material.h"
 #include "primitive.h"
-
-class Integrator;
 
 class Scene {
 public:
-    Scene() {};
+    Scene() = default;
+
     Scene(Camera cam,
-          unique_ptr<Integrator> &integ,
           map<string, shared_ptr<Material>> mats,
           map<string, shared_ptr<Primitive>> prims,
           map<string, shared_ptr<Primitive>> lights) :
-        camera(cam),
-        integrator(std::move(integ)),
-        materials(std::move(mats)),
-        primitives(std::move(prims)),
-        lights(std::move(lights)) {};
+            camera(cam),
+            materials(std::move(mats)),
+            primitives(std::move(prims)),
+            lights(std::move(lights)) {};
 
-    static Scene FromMitsubaXML(const char *filename);
-    static Scene FromTungstenJSON(const char* filename);
-
-    Camera camera;
-    unique_ptr<Integrator> integrator;
+    Camera camera{};
     map<string, shared_ptr<Material>> materials;
     map<string, shared_ptr<Primitive>> primitives;
     map<string, shared_ptr<Primitive>> lights;

--- a/renderer/src/sceneparser.h
+++ b/renderer/src/sceneparser.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "usings.h"
+
+#include "framebuffer.h"
+#include "integrator.h"
+#include "material.h"
+#include "primitive.h"
+#include "shape.h"
+#include "scene.h"
+
+#include <iostream>
+
+#include <nlohmann/json.hpp>
+#include "pugixml.hpp"
+
+using nlohmann::json;
+using value_type = json::value_type;
+
+using pugi::xml_document;
+using pugi::xml_named_node_iterator;
+using pugi::xml_node;
+using pugi::xml_object_range;
+using pugi::xml_parse_result;
+
+class SceneParser {
+public:
+    static void
+    FromMitsubaXML(Scene &scene, FrameBuffer &frame, unique_ptr<Integrator> &integrator, const char *filename);
+
+    static void
+    FromTungstenJSON(Scene &scene, FrameBuffer &frame, unique_ptr<Integrator> &integrator, const char *filename);
+};

--- a/renderer/src/shape.h
+++ b/renderer/src/shape.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "usings.h"
+
+class Shape {
+public:
+    explicit Shape(const mat4f &to_world) :
+            pos(vec3f()),
+            scale(vec3f()),
+            rot3(vec3f()),
+            rot4(mat4f()),
+            invRot(mat4f()),
+            to_world(to_world),
+            to_obj(inverse(to_world)) {};
+
+    Shape(const vec3f &pos,
+          const vec3f &scale,
+          const vec3f &rot3) :
+            pos(pos),
+            scale(scale),
+            rot3(rot3) {
+
+        mat4f T(1), R(1);
+        T = glm::translate(T, pos);
+        T = glm::scale(T, scale);
+        R = glm::rotate(R, rot3.x, vec3f(1, 0, 0));
+        R = glm::rotate(R, rot3.y, vec3f(0, 1, 0));
+        R = glm::rotate(R, rot3.z, vec3f(0, 0, 1));
+        T = T * R;
+
+        rot4 = R;
+        invRot = glm::inverse(rot4);
+        to_world = T;
+        to_obj = glm::inverse(T);
+    };
+
+    vec3f pos;
+    vec3f scale;
+    vec3f rot3;
+    mat4f rot4{};
+    mat4f invRot{};
+    mat4f to_world{};
+    mat4f to_obj{};
+};
+
+class Rectangle : public Shape {
+public:
+    explicit Rectangle(const mat4f &transform) : Shape(transform) {};
+
+    Rectangle(const vec3f &pos,
+              const vec3f &scale,
+              const vec3f &rot3) :
+            Shape(pos, scale, rot3) {};
+
+    vec3f a{-1, -1, 0};
+    vec3f b{1, 1, 0};
+    vec3f normal{0, 0, 1};
+};
+
+class Cube : public Shape {
+public:
+    explicit Cube(const mat4f &transform) : Shape(transform) {};
+
+    Cube(const vec3f &pos,
+         const vec3f &scale,
+         const vec3f &rot3) :
+            Shape(pos, scale, rot3) {};
+
+    vec3f a{-1, -1, -1};
+    vec3f b{1, 1, 1};
+};

--- a/renderer/src/usings.h
+++ b/renderer/src/usings.h
@@ -10,8 +10,6 @@
 
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
-#include <nlohmann/json.hpp>
-#include "pugixml.hpp"
 
 using std::map;
 using std::shared_ptr;
@@ -28,18 +26,6 @@ using vec4f = glm::f32vec4;
 using vec4c = glm::u8vec4;
 using mat4f = glm::f32mat4;
 
-using nlohmann::json;
-using value_type = json::value_type;
-
-using pugi::xml_document;
-using pugi::xml_named_node_iterator;
-using pugi::xml_node;
-using pugi::xml_object_range;
-using pugi::xml_parse_result;
-
-inline void __NO_OP() {}
-#define NO_OP __NO_OP ()
-
 const float PI = 3.1415926536f;
 const float PI_HALF = PI * 0.5f;
 const float TWO_PI = PI * 2.0f;
@@ -51,13 +37,15 @@ const float SQRT_PI = 1.77245385091f;
 const float INV_SQRT_PI = 1.0f / SQRT_PI;
 
 inline float clamp(float f) { return f < 0.0f ? 0.0f : (f > 1.0f ? 1.0f : f); }
+
 inline float d_to_r(float d) { return d * (PI / 180.0f); }
+
 inline float r_to_d(float r) { return r * (180.0f / PI); }
 
-inline vec3f transformVec(const mat4f& m, const vec3f& v) {
-    return vec3f(
-        m[0][0]*v.x + m[0][1]*v.y + m[0][2]*v.z,
-        m[1][0]*v.x + m[1][1]*v.y + m[1][2]*v.z,
-        m[2][0]*v.x + m[2][1]*v.y + m[2][2]*v.z
-    );
+inline vec3f transformVec(const mat4f &m, const vec3f &v) {
+    return {
+            m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
+            m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,
+            m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z
+    };
 }


### PR DESCRIPTION
- `clang-tidy` source files
- Fix circular dependencies in `scene` and `integrator`
- Split classes into files
- Move scene parsing into `SceneParser`
- Move Scene tracing to `Tracer`